### PR TITLE
Optimized getNewChunk() in the BukkitChunk classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ buildscript {
         mavenCentral()
         maven { url = "https://oss.sonatype.org/content/repositories/snapshots/" }
         jcenter()
+        maven { url 'https://jitpack.io' }
+        maven { url = "https://repo.codemc.org/repository/maven-public" }
     }
 	dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     compile 'com.sk89q.worldedit:worldedit-core:6.1.4-SNAPSHOT'
     compile 'com.thevoxelbox.voxelsniper:voxelsniper:5.171.0'
     compile 'com.comphenix.protocol:ProtocolLib-API:4.4.0'
+    compile 'com.wasteofplastic:askyblock:3.0.8.2'
     compile('org.inventivetalent:mapmanager:1.7.2-SNAPSHOT') {
         transitive = false
     }

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -13,7 +13,8 @@ dependencies {
     compile 'org.bukkit.craftbukkit:Craftbukkit_1_9:1.9.4'
     compile 'org.bukkit.craftbukkit:Craftbukkit_1_8:1.8.8'
     compile 'org.bukkit.craftbukkit:Craftbukkit_1_7:1.7.10'
-    compile 'net.milkbowl.vault:VaultAPI:1.5.6'
+    compile "com.github.MilkBowl:VaultAPI:1.7"
+    compile 'io.papermc:paperlib:1.0.6'
     compile 'com.massivecraft:factions:2.8.0'
     compile 'com.factionsone:FactionsOne:1.2.2'
     compile 'me.ryanhamshire:GriefPrevention:11.5.2'
@@ -27,7 +28,6 @@ dependencies {
     compile 'com.sk89q.worldedit:worldedit-core:6.1.4-SNAPSHOT'
     compile 'com.thevoxelbox.voxelsniper:voxelsniper:5.171.0'
     compile 'com.comphenix.protocol:ProtocolLib-API:4.4.0'
-    compile 'com.wasteofplastic:askyblock:3.0.8.2'
     compile('org.inventivetalent:mapmanager:1.7.2-SNAPSHOT') {
         transitive = false
     }
@@ -87,6 +87,7 @@ shadowJar {
         include(dependency('com.github.luben:zstd-jni:1.1.1'))
         include(dependency('co.aikar:fastutil-lite:1.0'))
         include(dependency(':core'))
+        include(dependency('io.papermc:paperlib:1.0.6'))
     }
     archiveName = "${parent.name}-${project.name}-${parent.version}.jar"
     destinationDir = file '../target'

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v0/BukkitChunk_All.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v0/BukkitChunk_All.java
@@ -24,6 +24,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import io.papermc.lib.PaperLib;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.ChunkSnapshot;
@@ -66,7 +69,12 @@ public class BukkitChunk_All extends CharFaweChunk<Chunk, BukkitQueue_All> {
 
     @Override
     public Chunk getNewChunk() {
-        return Bukkit.getWorld(getParent().getWorldName()).getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     private int layer = -1;

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_10/BukkitChunk_1_10.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_10/BukkitChunk_1_10.java
@@ -16,6 +16,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import io.papermc.lib.PaperLib;
 import net.minecraft.server.v1_10_R1.*;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -102,7 +105,12 @@ public class BukkitChunk_1_10 extends CharFaweChunk<Chunk, BukkitQueue_1_10> {
 
     @Override
     public Chunk getNewChunk() {
-        return ((com.boydti.fawe.bukkit.v1_10.BukkitQueue_1_10) getParent()).getWorld().getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public DataPaletteBlock newDataPaletteBlock() {

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_11/BukkitChunk_1_11.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_11/BukkitChunk_1_11.java
@@ -27,6 +27,9 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+
+import io.papermc.lib.PaperLib;
 import net.minecraft.server.v1_11_R1.Block;
 import net.minecraft.server.v1_11_R1.BlockPosition;
 import net.minecraft.server.v1_11_R1.ChunkSection;
@@ -158,7 +161,12 @@ public class BukkitChunk_1_11 extends CharFaweChunk<Chunk, com.boydti.fawe.bukki
 
     @Override
     public Chunk getNewChunk() {
-        return ((com.boydti.fawe.bukkit.v1_11.BukkitQueue_1_11) getParent()).getWorld().getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public DataPaletteBlock newDataPaletteBlock() {

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_12/BukkitChunk_1_12.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_12/BukkitChunk_1_12.java
@@ -12,6 +12,7 @@ import com.boydti.fawe.util.MathMan;
 import com.boydti.fawe.util.ReflectionUtils;
 import com.sk89q.jnbt.*;
 import com.sk89q.worldedit.internal.Constants;
+import io.papermc.lib.PaperLib;
 import net.minecraft.server.v1_12_R1.*;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -22,6 +23,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 public class BukkitChunk_1_12 extends CharFaweChunk<Chunk, BukkitQueue_1_12> {
 
@@ -135,7 +137,12 @@ public class BukkitChunk_1_12 extends CharFaweChunk<Chunk, BukkitQueue_1_12> {
 
     @Override
     public Chunk getNewChunk() {
-        return ((BukkitQueue_1_12) getParent()).getWorld().getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public DataPaletteBlock newDataPaletteBlock() {

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_7/BukkitChunk_1_7.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_7/BukkitChunk_1_7.java
@@ -14,6 +14,9 @@ import com.sk89q.jnbt.StringTag;
 import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.internal.Constants;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import io.papermc.lib.PaperLib;
 import net.minecraft.server.v1_7_R4.*;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -25,7 +28,12 @@ public class BukkitChunk_1_7 extends CharFaweChunk<Chunk, BukkitQueue17> {
 
     @Override
     public Chunk getNewChunk() {
-        return Bukkit.getWorld(getParent().getWorldName()).getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public final byte[][] byteIds;

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_8/BukkitChunk_1_8.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_8/BukkitChunk_1_8.java
@@ -14,8 +14,10 @@ import com.sk89q.jnbt.StringTag;
 import com.sk89q.jnbt.Tag;
 import com.sk89q.worldedit.internal.Constants;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import io.papermc.lib.PaperLib;
 import net.minecraft.server.v1_8_R3.*;
-import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.v1_8_R3.CraftChunk;
@@ -54,7 +56,12 @@ public class BukkitChunk_1_8 extends CharFaweChunk<Chunk, BukkitQueue18R3> {
 
     @Override
     public Chunk getNewChunk() {
-        return Bukkit.getWorld(getParent().getWorldName()).getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     @Override

--- a/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_9/BukkitChunk_1_9.java
+++ b/bukkit/src/main/java/com/boydti/fawe/bukkit/v1_9/BukkitChunk_1_9.java
@@ -14,6 +14,9 @@ import com.sk89q.worldedit.internal.Constants;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
+
+import io.papermc.lib.PaperLib;
 import net.minecraft.server.v1_9_R2.*;
 import org.bukkit.Chunk;
 import org.bukkit.World;
@@ -101,7 +104,12 @@ public class BukkitChunk_1_9 extends CharFaweChunk<Chunk, BukkitQueue_1_9_R1> {
 
     @Override
     public Chunk getNewChunk() {
-        return ((BukkitQueue_1_9_R1) getParent()).getWorld().getChunkAt(getX(), getZ());
+        try {
+            return PaperLib.getChunkAtAsync(getParent().getWorld(), getX(), getZ(), true, true).get(); // Get chunks async
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+        return null;
     }
 
     public DataPaletteBlock newDataPaletteBlock() {


### PR DESCRIPTION
I have optimized the getNewChunk() method inside of all of the "BukkitChunk_" classes in order to prevent lag from thread locking, this can happen when you are pasting a lot of schematics in unloaded chunks and causes a server's TPS to drop dramatically. 
This fix stops this from happening.